### PR TITLE
Changed error reporting info when validating the json is parseable. 

### DIFF
--- a/src/main/java/com/groupon/maven/plugin/json/DefaultValidatorExecutor.java
+++ b/src/main/java/com/groupon/maven/plugin/json/DefaultValidatorExecutor.java
@@ -104,11 +104,11 @@ public class DefaultValidatorExecutor implements ValidatorExecutor {
     private JsonNode loadJson(final String file) throws MojoExecutionException {
         try {
             final JsonNode node = JsonLoader.fromPath(file);
-            request.getLog().info("Loaded JSON from " + file);
             return node;
         } catch (final IOException io) {
+            request.getLog().error("Failed to parse JSON from '" + file + "'");
             request.getLog().error(io);
-            throw new MojoExecutionException("IOException loading JSON", io);
+            throw new MojoExecutionException("Failed to parse JSON from file '" + file + "'", io);
         }
     }
 

--- a/src/main/java/com/groupon/maven/plugin/json/DefaultValidatorExecutor.java
+++ b/src/main/java/com/groupon/maven/plugin/json/DefaultValidatorExecutor.java
@@ -73,12 +73,27 @@ public class DefaultValidatorExecutor implements ValidatorExecutor {
         if (!StringUtils.isEmpty(validation.getJsonSchema())) {
             schemaFile = FileUtils.locateInputFile(validation.getJsonSchema(), inputLocator);
         }
+        List<Exception> exceptions = new ArrayList<>();
         for (final String jsonFile : jsonFiles) {
-            if (schemaFile != null) {
-                validateAgainstSchema(jsonFile, schemaFile);
-            } else {
-                loadJson(jsonFile);
+            try {
+                if (schemaFile != null) {
+                    validateAgainstSchema(jsonFile, schemaFile);
+                } else {
+                    loadJson(jsonFile);
+                }
+            } catch (MojoExecutionException | MojoFailureException e) {
+                exceptions.add(e);
             }
+        }
+
+        if (exceptions.size() > 0) {
+            request.getLog().error("Failed validating json files, " + exceptions.size() + " failures");
+            for (Exception e : exceptions) {
+                request.getLog().error(e.getMessage());
+            }
+            throw new MojoFailureException("Failed while validating json files.");
+        } else {
+            request.getLog().info("Succesfully processed " + jsonFiles.size() + " files.");
         }
     }
 
@@ -90,10 +105,10 @@ public class DefaultValidatorExecutor implements ValidatorExecutor {
             final JsonSchema schema = factory.getJsonSchema(schemaResource);
             final ProcessingReport report = schema.validate(fileResouce);
             if (!report.isSuccess()) {
-                request.getLog().error("Failed validating JSON from " + jsonDataFile + " against " + schemaFile);
-                throw new MojoFailureException(report.toString());
+                request.getLog().error("File: " + jsonDataFile + " - validation against " + schemaFile + " - Failure");
+                throw new MojoFailureException("Failed to validate JSON from file '" + jsonDataFile + "' - " + report.toString());
             } else {
-                request.getLog().info("Successfully validated JSON from " + jsonDataFile + " against " + schemaFile);
+                request.getLog().info("File: " + jsonDataFile + " - validation against " + schemaFile + " - Success");
             }
         } catch (final ProcessingException e) {
             request.getLog().error(e);
@@ -104,11 +119,11 @@ public class DefaultValidatorExecutor implements ValidatorExecutor {
     private JsonNode loadJson(final String file) throws MojoExecutionException {
         try {
             final JsonNode node = JsonLoader.fromPath(file);
+            request.getLog().info("File: " + file + " - parsing Json - Success");
             return node;
         } catch (final IOException io) {
-            request.getLog().error("Failed to parse JSON from '" + file + "'");
-            request.getLog().error(io);
-            throw new MojoExecutionException("Failed to parse JSON from file '" + file + "'", io);
+            request.getLog().error("File: " + file + " - parsing Json - Failure");
+            throw new MojoExecutionException("Failed to parse JSON from file '" + file + "' - " + io.getMessage(), io);
         }
     }
 

--- a/src/test/java/org/apache/maven/plugin/validator/ValidatorMojoTest.java
+++ b/src/test/java/org/apache/maven/plugin/validator/ValidatorMojoTest.java
@@ -125,7 +125,7 @@ public class ValidatorMojoTest extends AbstractMojoTestCase {
             mojo.execute();
             fail("Must throw an exception");
         } catch (final Exception e) {
-            assertEquals(MojoExecutionException.class, e.getClass());
+            assertEquals(MojoFailureException.class, e.getClass());
         }
     }
 
@@ -161,7 +161,7 @@ public class ValidatorMojoTest extends AbstractMojoTestCase {
             mojo.execute();
             fail("Must throw an exception");
         } catch (final Exception e) {
-            assertEquals(MojoExecutionException.class, e.getClass());
+            assertEquals(MojoFailureException.class, e.getClass());
         }
     }
 


### PR DESCRIPTION
I removed the info lines that report that the files were loaded successfully and add the filename onto a error line before the parsing exception and into the final failure output.

Example:
```
[INFO] --- json-schema-validator:1.2.1-SNAPSHOT:validate (default) @ api-proxy-config ---
[ERROR] Failed to parse JSON from '/Users/gil/code/api-proxy-config/src/main/conf/staging/routingConf.json'
[ERROR] 
com.fasterxml.jackson.core.JsonParseException: Unexpected character ('{' (code 123)): was expecting comma to separate ARRAY entries
 at [Source: java.io.FileInputStream@7c455e96; line: 1846, column: 18]
	at com.fasterxml.jackson.core.JsonParser._constructError(JsonParser.java:1581)
	at com.fasterxml.jackson.core.base.ParserMinimalBase._reportError(ParserMinimalBase.java:533)
	at com.fasterxml.jackson.core.base.ParserMinimalBase._reportUnexpectedChar(ParserMinimalBase.java:462)
	at com.fasterxml.jackson.core.json.UTF8StreamJsonParser.nextToken(UTF8StreamJsonParser.java:727)
	at com.fasterxml.jackson.databind.deser.std.BaseNodeDeserializer.deserializeArray(JsonNodeDeserializer.java:229)
	at com.fasterxml.jackson.databind.deser.std.BaseNodeDeserializer.deserializeObject(JsonNodeDeserializer.java:207)
	at com.fasterxml.jackson.databind.deser.std.BaseNodeDeserializer.deserializeArray(JsonNodeDeserializer.java:235)
	at com.fasterxml.jackson.databind.deser.std.BaseNodeDeserializer.deserializeObject(JsonNodeDeserializer.java:207)
	at com.fasterxml.jackson.databind.deser.std.JsonNodeDeserializer.deserialize(JsonNodeDeserializer.java:59)
	at com.fasterxml.jackson.databind.deser.std.JsonNodeDeserializer.deserialize(JsonNodeDeserializer.java:15)
	at com.fasterxml.jackson.databind.MappingIterator.nextValue(MappingIterator.java:189)
	at com.github.fge.jackson.JsonNodeReader.readNode(JsonNodeReader.java:145)
	at com.github.fge.jackson.JsonNodeReader.fromInputStream(JsonNodeReader.java:103)
	at com.github.fge.jackson.JsonLoader.fromPath(JsonLoader.java:136)
	at com.groupon.maven.plugin.json.DefaultValidatorExecutor.loadJson(DefaultValidatorExecutor.java:106)
	at com.groupon.maven.plugin.json.DefaultValidatorExecutor.performValidation(DefaultValidatorExecutor.java:80)
	at com.groupon.maven.plugin.json.DefaultValidatorExecutor.executeValidator(DefaultValidatorExecutor.java:59)
	at com.groupon.maven.plugin.json.ValidatorMojo.execute(ValidatorMojo.java:55)
	at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:134)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:208)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:153)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:145)
	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:116)
	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:80)
	at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build(SingleThreadedBuilder.java:51)
	at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:128)
	at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:307)
	at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:193)
	at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:106)
	at org.apache.maven.cli.MavenCli.execute(MavenCli.java:862)
	at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:286)
	at org.apache.maven.cli.MavenCli.main(MavenCli.java:197)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:497)
	at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:289)
	at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:229)
	at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:415)
	at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:356)
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 0.908 s
[INFO] Finished at: 2016-03-03T13:41:47-08:00
[INFO] Final Memory: 11M/297M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal com.groupon.maven.plugin.json:json-schema-validator:1.2.1-SNAPSHOT:validate (default) on project api-proxy-config: Failed to parse JSON from file '/Users/gil/code/api-proxy-config/src/main/conf/staging/routingConf.json': Unexpected character ('{' (code 123)): was expecting comma to separate ARRAY entries
[ERROR] at [Source: java.io.FileInputStream@7c455e96; line: 1846, column: 18]
```